### PR TITLE
WIP: Add Markua rendering script

### DIFF
--- a/scripts/render-markua.R
+++ b/scripts/render-markua.R
@@ -1,0 +1,131 @@
+# Rendering script which makes bookdown Rmds into Markua friendly markdowns
+# Candace Savonen 
+# April 2021
+
+# This script assumes that the bookdown Rmd files are in the base git directory. 
+
+# Command line example:
+# Rscript scripts/render-markua.R --o "manuscript" --bookdown
+
+library(optparse)
+
+################################ Set up options ################################
+# Option descriptions
+# Set up optparse options
+option_list <- list(
+  make_option(
+    opt_str = c("-b", "--bookdown"), action = "store_true",
+    default = FALSE, help = "If used re-run bookdown",
+    metavar = "character"), 
+  make_option(
+    opt_str = c("-o", "--output_dir"), type = "character",
+    default = NULL, help = "Directory that you would like all output Markua ready
+    markdown files to be stored. If it doesn't exist, it will be created.",
+    metavar = "character"
+  ), 
+  make_option(
+    opt_str = c("-i", "--images_dir"), type = "character",
+    default = "resources/images", help = "Directory where the images are located",
+    metavar = "character"
+  )
+  )
+
+# Parse options
+opt <- parse_args(OptionParser(option_list = option_list))
+
+################################ Directory set up ##############################
+# Where's the destination folder?
+manuscript_dir <- opt$output_dir
+
+# Where the images should end up
+images_dest <- file.path(manuscript_dir, opt$images_dir)
+
+# Remove all the old files if they exist
+if (dir.exists(images_dest)){
+  system(paste("rm -r", images_dest))
+}
+
+# Copy over images that are otherwise needed
+system(paste("cp -r", dirname(opt$images_dir), manuscript_dir))
+
+# Establish base dir by looking for .git file
+root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
+
+# Optionally re-serve the bookdown
+if (opt$bookdown) {
+  # Run bookdown
+  bookdown::serve_book(dir = root_dir, 
+                       preview = FALSE)
+}
+
+# Obtain the list of Rmd files we want to convert
+rmds <- list.files(path = root_dir, pattern = "\\.Rmd")
+
+# Exclude index file
+rmds <- grep("index", rmds, invert = TRUE, value = TRUE)
+  
+# Establish a function to convert an Rmd -> Markua friendly md
+make_markua <- function(rmd, 
+                        output_folder = manuscript_dir, 
+                        image_folder = images_dest) {
+  # When supplied a file path to an Rmd, snag the markdown intermediate file and 
+  # add Markua tags to image and video links. Then save the final adjusted file 
+  # to the output directory supplied.
+  #
+  # Args:
+  #   rmd : A file path to an Rmd to be converted to something Markua friendly
+  #   output_folder : Where the final Markua friendly file should go
+  #   image_folder : The file path to where images should go
+  #
+  # Returns:
+  # A Markua friendly file and its associated plots
+  
+  # Get the basename of the file
+  base_name <- gsub("\\.Rmd", "", rmd)
+  
+  # Declare location of where the figures should be stored
+  fig_loc <- file.path(image_folder, base_name, "")
+  
+  # Create this directory if it doesn't exist yet
+  if (!dir.exists(fig_loc)) {
+    dir.create(fig_loc, recursive = TRUE)
+  }
+  
+  # Run the rendering
+  rmarkdown::render(rmd,
+                    intermediates_dir = output_folder,
+                    output_dir = output_folder,
+                    clean = FALSE, # We have to say clean false so plots stay
+                    run_pandoc = FALSE,
+                    output_format = rmarkdown::output_format(
+                      knitr = rmarkdown::knitr_options(opts_chunk = list(fig.path = fig_loc)),
+                      # We aren't running pandoc but it doesn't like not having something for this argument
+                      pandoc = rmarkdown::pandoc_options(to = "md"))
+                    )
+  
+  # But now, we have to pay the consequences for using clean = FALSE and pandoc
+  file.remove(file.path(output_folder, paste0(base_name, ".utf8.md")))
+  
+  # Declare markdown file name and path for the one we want
+  md_file <- file.path(output_folder, paste0(base_name, ".knit.md"))
+  
+  ##### Add Markua tags to all images
+  # Read in as lines
+  lines <- readr::read_lines(md_file)
+    
+  # Set up image tag that will be used for all images
+  image_tag <- "{alt: 'an image', width=80%}"
+  
+  # Find which lines have markdown links
+  new_lines <- stringr::str_replace(lines, "\\!\\[", paste0(image_tag, "\\!\\["))
+  
+  # Overwrite markdown file
+  readr::write_lines(new_lines, md_file)
+  
+  message(paste(md_file, "is prepped!"))
+}
+
+# Run this on all the files!
+purrr::map(rmds, make_markua, 
+           output_folder = manuscript_dir, 
+           image_folder = opt$images_dir)


### PR DESCRIPTION
**This PR is a replicate of the original that was started on the other, bookdown, repo:** https://github.com/jhudsl/ITCR_Course_Template_Bookdown/pull/15

### Summary 

This renders each Rmd as a markdown that Markua should like and adds Markua format tags for each image. The usage for this would just be calling the script itself so:

```
Rscript scripts/render-markua.R -o "manuscript"
```
It also needs to have a bit that makes it add to `Book.txt` as we can see that that is easy to forget to do. 
I haven't added a thing for Markua tags for videos and it probably needs polishing elsewhere. 