### PR TITLE
Add get_rmd_filenames.R script

### DIFF
--- a/scripts/get_rmd_filenames.R
+++ b/scripts/get_rmd_filenames.R
@@ -1,0 +1,15 @@
+# Retrieve Rmd names from _bookdown.yml to be given to github actions for 
+# copying over files to Leanpub repo
+# C. Savonen 2021
+
+# Read bookdown.yml
+yml <- readLines("_bookdown.yml") 
+
+# Only keep lines with Rmd filename
+yml <- grep("\\.Rmd", yml, value = TRUE, ignore.case = TRUE)
+
+# Take out the nonsense
+yml <- gsub(",|\t| |\\[|\\]|:|rmd_files|\"", "", yml)
+
+# Write the file
+writeLines(yml, file.path("resources", "rmd_list.txt"))


### PR DESCRIPTION
Related to issues over on https://github.com/jhudsl/DaSL_Course_Template_Bookdown/runs/3400556975?check_suite_focus=true

I'm trying to get Rmd files over here in a way that's not janky. I figured the best way is for us to take the file names directly from the _bookdown.yml. 

So that's what this script does. It will be called by a github actions in transfer-rendered-files.yml over in the _Bookdown repo. 