### PR TITLE
Add directory creation in rmd_filename script

### DIFF
--- a/scripts/get_rmd_filenames.R
+++ b/scripts/get_rmd_filenames.R
@@ -11,5 +11,9 @@ yml <- grep("\\.Rmd", yml, value = TRUE, ignore.case = TRUE)
 # Take out the nonsense
 yml <- gsub(",|\t| |\\[|\\]|:|rmd_files|\"", "", yml)
 
+if(!dir.exists("resources")){
+  dir.create("resources")
+}
+
 # Write the file
 writeLines(yml, file.path("resources", "rmd_list.txt"))


### PR DESCRIPTION
Related to this error: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/runs/3401153881?check_suite_focus=true

Realized we need to create the resources folder in this repo if it does not yet exist. 