### PR TITLE
Some polishing of coursera quiz conversion

### DIFF
--- a/scripts/coursera_quiz_conversion.R
+++ b/scripts/coursera_quiz_conversion.R
@@ -4,6 +4,8 @@
 # This is functionalized but running like script for now till we decide where to put this:
 # run by  pasting `Rscript scripts/coursera_quiz_conversion.R` in the terminal
 
+# Need magrittr
+`%>%` <- dplyr::`%>%`
 
 find_end_of_prompt <- function(start_prompt_index, type_vector) {
   # Given an index of the start of a prompt, find the end of it. The end of the prompt is identified by finding the beginning of the answers
@@ -53,11 +55,13 @@ convert_quiz <- function(quiz_path, output_dir, verbose = TRUE) {
   #   a coursera ready quiz saved to the output directory specified
 
   # Print out which quiz we're converting
-  message(paste("Converting quiz:", quiz))
+  message(paste("Converting quiz:", quiz_path))
+
+  output_filename <- file.path(output_dir, paste0(basename(quiz_path), ".yml"))
 
   ### First read lines for each quiz
   # Put it as a data.frame:
-  quiz_lines_df <- data.frame(quiz_lines = readLines(file.path(path, quiz))) %>%
+  quiz_lines_df <- data.frame(quiz_lines = readLines(file.path(quiz_path))) %>%
     dplyr::mutate(type = dplyr::case_when(
       # Find starts to questions:
       grepl("^\\?", quiz_lines) ~ "prompt",
@@ -134,13 +138,13 @@ convert_quiz <- function(quiz_path, output_dir, verbose = TRUE) {
   )
 
   ### Write new file with .yml at end of file name and put in coursera dir
-  writeLines(updated_quiz_lines, con = file.path(output_dir, paste0(quiz, ".yml")))
+  writeLines(updated_quiz_lines, con = output_filename)
 
   # Put message
-  message(paste("Converted quiz saved to:", file.path(output_dir, paste0(quiz, ".yml"))))
+  message(paste("Converted quiz saved to:", output_filename))
 }
 
-convert_coursera_quizzes <- function(quiz_path = "quizzes",
+convert_coursera_quizzes <- function(quiz_dir = "quizzes",
                                      output_dir = "coursera_quizzes",
                                      verbose = TRUE) {
 
@@ -148,15 +152,12 @@ convert_coursera_quizzes <- function(quiz_path = "quizzes",
   # by passing them to `convert_quiz`.
   #
   # Args:
-  #   quiz_path: a path to a directory of leanpub formatted quiz md files
+  #   quiz_dir: a path to a directory of leanpub formatted quiz md files
   #   output_dir: a folder (existing or not) that the new coursera converted quizzes should be saved to.
   #   verbose: would you like the progress messages?
   #
   # Returns:
   #   a coursera ready quiz saved to the output directory specified
-
-  # Need magrittr
-  `%>%` <- dplyr::`%>%`
 
   # Create directory if it is not yet created
   if (!dir.exists(output_dir)) {
@@ -167,12 +168,12 @@ convert_coursera_quizzes <- function(quiz_path = "quizzes",
   leanpub_quizzes <- list.files(
     pattern = (".md"),
     ignore.case = TRUE,
-    path = path,
-    full.names = FALSE
+    path = quiz_dir,
+    full.names = TRUE
   )
 
   if (length(leanpub_quizzes) < 1) {
-    stop(paste0("No quiz .md files found in your specified path dir of: ", path))
+    stop(paste0("No quiz .md files found in your specified path dir of: ", quiz_path))
   }
 
   # Run the thing!
@@ -181,3 +182,6 @@ convert_coursera_quizzes <- function(quiz_path = "quizzes",
          verbose = verbose,
          output_dir = output_dir)
 }
+
+# RUN IT!
+convert_coursera_quizzes()

--- a/scripts/coursera_quiz_conversion.R
+++ b/scripts/coursera_quiz_conversion.R
@@ -155,6 +155,15 @@ convert_quiz <- function(quiz_path, output_dir, verbose = TRUE) {
                                         values = ""
   )
 
+  # Trim trailing space
+  updated_quiz_lines <- trimws(updated_quiz_lines, which = "right")
+
+  # Add extra line in between each question
+  updated_quiz_lines <- stringr::str_remove(updated_quiz_lines, ":$")
+
+  # Return the options : though
+  updated_quiz_lines <- stringr::str_replace(updated_quiz_lines, "  options", "  options:")
+
   ### Write new file with .yml at end of file name and put in coursera dir
   writeLines(updated_quiz_lines, con = output_filename)
 

--- a/scripts/coursera_quiz_conversion.R
+++ b/scripts/coursera_quiz_conversion.R
@@ -4,105 +4,17 @@
 # This is functionalized but running like script for now till we decide where to put this:
 # run by  pasting `Rscript scripts/coursera_quiz_conversion.R` in the terminal
 
-coursera_quizzes <- function(path = file.path("quizzes"), # we might want to update to manuscript
-                             verbose = TRUE) {
-  # Need magrittr
-  `%>%` <- dplyr::`%>%`
 
-  # List quiz paths
-  leanpub_quizzes = list.files(
-    pattern = (".md"),
-    ignore.case = TRUE,
-    path = path,
-    full.names = FALSE)
-
-  if (length(leanpub_quizzes) < 1) {
-    stop(paste0("No quiz .md files found in your specified path dir of: ", path))
-  }
-
-  for(quiz in leanpub_quizzes){
-
-    # Print out which quiz we're converting
-    message(paste("Converting quiz:", quiz))
-
-    ### First read lines for each quiz
-    quiz_lines  <- readLines(file.path(path, quiz))
-
-    # Put it as a data.frame:
-    quiz_lines_df <- data.frame(quiz_lines) %>%
-      dplyr::mutate(type = dplyr::case_when(
-        # Find starts to questions:
-        grepl("^\\?", quiz_lines) ~ "prompt",
-        # Find which lines are the wrong answer options
-        grepl("^[[:lower:]]{1}\\)", quiz_lines) ~ "wrong_answer",
-        # Find which lines are the correct answer options
-        grepl("^[[:upper:]]{1}\\)", quiz_lines) ~ "correct_answer",
-        # Find the tags
-        grepl("^\\{", quiz_lines) ~ "tag",
-        # Mark empty lines
-        nchar(quiz_lines) == 0 ~ "empty",
-        # Mark everything else as "other
-        TRUE ~ "other"
-      )) %>%
-      # Remove empty lines
-        dplyr::filter(type != "empty")
-    %>%
-      # Now for updating based on type!
-      dplyr::mutate(updated_line = dplyr::case_when(
-        type == "prompt" ~ stringr::str_replace(quiz_lines, "^\\?", "prompt:"),
-        grepl(type, "answer") ~ stringr::str_replace(quiz_lines, "^[[:alpha:]]\\)", "    - answer:"),
-        TRUE ~ quiz_lines
-      ))
-
-    ###### Find extended prompts
-    # Get the starts of prompts
-    start_prompt_indices <- which(quiz_lines_df$type == "prompt")
-
-    # Find the line which the footnote ends at
-    end_prompt_indices <- sapply(start_prompt_indices,
-                                 find_end_of_prompt,
-                                 type_vector = quiz_lines_df$type)
-
-    # Rename "other" as also part of prompts
-    for (index in 1:length(start_prompt_indices)) {
-      if (start_prompt_indices[index] != end_prompt_indices[index]) {
-      quiz_lines_df$type[(start_prompt_indices[index] + 1):(end_prompt_indices[index] - 1)] <- "extended_prompt"
-      }
-    }
-
-    ### Now to update question prompts
-    prompt_loc <- which(quiz_lines_df$type == "prompt")
-
-    # Start each question with this type:
-    quiz_lines <- R.utils::insert(quiz_lines, ats = (prompt_loc + 1), values = "- typeName: multipleChoice")
-
-    # Add "  shuffleoptions: true" to the line after question prompts (the lines with ? - may be after the line with prompt:)
-    quiz_lines <- R.utils::insert(quiz_lines, ats = (prompt_loc + 1), values = "  shuffleOptions: true")
-
-    # Add "  options:" in the line after those just added
-    quiz_lines <- R.utils::insert(quiz_lines, ats = (prompt_loc + 2), values = "  options:")
-
-    # Modify lines that start with number for prompt so that they have 4 spaces in front
-    quiz_lines[grep("^[1-9].", quiz_lines)] <- paste0("    ", quiz_lines[grep("^[1-9].", quiz_lines)])
-
-    # Need to add "isCorrect: true" one line below correct value lines
-    quiz_lines <-R.utils::insert(quiz_lines, ats = (Correct_loc + 1), values = "      isCorrect: true")
-
-    # Need to add "isCorrect: false" one line below incorrect value lines
-    quiz_lines <- R.utils::insert(quiz_lines, ats = (Wrong_loc + 1), values = "      isCorrect: false")
-
-    ### Write new file with .yml at end of file name and put in coursera dir
-    writeLines(quiz_lines, con=file.path(here::here("coursera"), paste0(quiz, ".yml")))
-  }
-}
-
-### Run function
-coursera_quizzes()
-
-
-# Given an index of the start of a prompt, find the end of it.
-# The end of the prompt is identified by finding the beginning of the answers
 find_end_of_prompt <- function(start_prompt_index, type_vector) {
+  # Given an index of the start of a prompt, find the end of it. The end of the prompt is identified by finding the beginning of the answers
+  # Given a vector of what type of line something is, look for the end of the prompt for a given index
+  #
+  # Args:
+  #   start_prompt_index: a single index to start the search at (the beginning of the prompt)
+  #   type_vector: A vector indicating the type of line -- will look for "answer" to indicate that the prompt has ended.
+  #
+  # Returns:
+  #   The index of the end of the prompt
 
   # We want to see if the next line is where the answers start
   end_prompt_index <- start_prompt_index + 1
@@ -126,5 +38,146 @@ find_end_of_prompt <- function(start_prompt_index, type_vector) {
   } else {
     end_prompt_index <- start_prompt_index
   }
-  return(end_prompt_index - 1)
+  return(end_prompt_index)
+}
+
+convert_quiz <- function(quiz_path, output_dir, verbose = TRUE) {
+  # Make a leanpub formatted md file quiz into a coursera yaml file quiz
+  #
+  # Args:
+  #   quiz_path: a path to a quiz .md file
+  #   output_dir: an existing folder where you would like the new version of the quiz to be saved
+  #   verbose: would you like the progress messages?
+  #
+  # Returns:
+  #   a coursera ready quiz saved to the output directory specified
+
+  # Print out which quiz we're converting
+  message(paste("Converting quiz:", quiz))
+
+  ### First read lines for each quiz
+  # Put it as a data.frame:
+  quiz_lines_df <- data.frame(quiz_lines = readLines(file.path(path, quiz))) %>%
+    dplyr::mutate(type = dplyr::case_when(
+      # Find starts to questions:
+      grepl("^\\?", quiz_lines) ~ "prompt",
+      # Find which lines are the wrong answer options
+      grepl("^[[:lower:]]{1}\\)", quiz_lines) ~ "wrong_answer",
+      # Find which lines are the correct answer options
+      grepl("^[[:upper:]]{1}\\)", quiz_lines) ~ "correct_answer",
+      # Find the tags
+      grepl("^\\{", quiz_lines) ~ "tag",
+      # Mark empty lines
+      nchar(quiz_lines) == 0 ~ "empty",
+      # Mark everything else as "other
+      TRUE ~ "other"
+    )) %>%
+    # Remove empty lines
+    dplyr::filter(!(type %in% c("empty", "tag")))
+
+  ###### Find extended prompts
+  # Get the starts of prompts
+  start_prompt_indices <- which(quiz_lines_df$type == "prompt")
+
+  # Find the line which the footnote ends at
+  end_prompt_indices <- sapply(start_prompt_indices,
+    find_end_of_prompt,
+    type_vector = quiz_lines_df$type
+  )
+
+  # Rename "other" as also part of prompts
+  for (index in 1:length(start_prompt_indices)) {
+    if (start_prompt_indices[index] != end_prompt_indices[index]) {
+      quiz_lines_df$type[(start_prompt_indices[index] + 1):(end_prompt_indices[index] - 1)] <- "extended_prompt"
+    }
+  }
+
+  quiz_lines_df <- quiz_lines_df %>%
+    # Now for updating based on type!
+    dplyr::mutate(updated_line = dplyr::case_when(
+      type == "prompt" ~ stringr::str_replace(quiz_lines, "^\\?", "prompt:"),
+      type == "extended_prompt" ~ paste0("    ", quiz_lines),
+      grepl("answer", type) ~ stringr::str_replace(quiz_lines, "^[[:alpha:]]\\)", "    - answer:"),
+      TRUE ~ quiz_lines
+    ))
+
+  # Turn updated lines into a named vector
+  updated_quiz_lines <- quiz_lines_df$updated_line
+  names(updated_quiz_lines) <- quiz_lines_df$type
+
+
+  ### Add "  options:" before beginning of answer options
+  updated_quiz_lines <- R.utils::insert(updated_quiz_lines, ats = end_prompt_indices + 1, values = "  options:")
+
+  ### Add specs for coursera
+  # Add typeName before prompt starts:
+  updated_quiz_lines <- R.utils::insert(updated_quiz_lines,
+    ats = which(names(updated_quiz_lines) == "prompt") - 1,
+    values = "- typeName: multipleChoice"
+  )
+
+  # Add shuffleoptions: true after prompt ends
+  updated_quiz_lines <- R.utils::insert(updated_quiz_lines,
+    ats = which(names(updated_quiz_lines) == "prompt") + 1,
+    values = "  shuffleOptions: true"
+  )
+
+  # Need to add "isCorrect: true" one line below correct value lines
+  updated_quiz_lines <- R.utils::insert(updated_quiz_lines,
+    ats = which(names(updated_quiz_lines) == "correct_answer"),
+    values = "      isCorrect: true"
+  )
+  # Need to add "isCorrect: false" one line below incorrect value lines
+  updated_quiz_lines <- R.utils::insert(updated_quiz_lines,
+    ats = which(names(updated_quiz_lines) == "wrong_answer"),
+    values = "      isCorrect: false"
+  )
+
+  ### Write new file with .yml at end of file name and put in coursera dir
+  writeLines(updated_quiz_lines, con = file.path(output_dir, paste0(quiz, ".yml")))
+
+  # Put message
+  message(paste("Converted quiz saved to:", file.path(output_dir, paste0(quiz, ".yml"))))
+}
+
+convert_coursera_quizzes <- function(quiz_path = "quizzes",
+                                     output_dir = "coursera_quizzes",
+                                     verbose = TRUE) {
+
+  # Given a directory of Leanpub quiz md files, convert all quizzes to Coursera compatible quizzes
+  # by passing them to `convert_quiz`.
+  #
+  # Args:
+  #   quiz_path: a path to a directory of leanpub formatted quiz md files
+  #   output_dir: a folder (existing or not) that the new coursera converted quizzes should be saved to.
+  #   verbose: would you like the progress messages?
+  #
+  # Returns:
+  #   a coursera ready quiz saved to the output directory specified
+
+  # Need magrittr
+  `%>%` <- dplyr::`%>%`
+
+  # Create directory if it is not yet created
+  if (!dir.exists(output_dir)) {
+    dir.create(output_dir, recursive = TRUE)
+  }
+
+  # List quiz paths
+  leanpub_quizzes <- list.files(
+    pattern = (".md"),
+    ignore.case = TRUE,
+    path = path,
+    full.names = FALSE
+  )
+
+  if (length(leanpub_quizzes) < 1) {
+    stop(paste0("No quiz .md files found in your specified path dir of: ", path))
+  }
+
+  # Run the thing!
+  lapply(leanpub_quizzes,
+         convert_quiz,
+         verbose = verbose,
+         output_dir = output_dir)
 }


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
The script for converting quizzes from leanpub ->  coursera didn't work for my quizzes, so I did some adjusting. This should be more broadly applicable (I think). It's been working so far. 

I will do more testing to make sure. This is something we could add to a potential CourseraBuild: https://github.com/jhudsl/DaSL_Course_Template_Bookdown/issues/166


#### What was your approach?
There are three functions: 

`find_end_of_prompt()`
`convert_quiz()`
`convert_coursera_quizzes()`

The main function `convert_coursera_quizzes()` takes an input and output directory to convert all quizzes. It calls `convert_quiz()` for each quiz. `find_end_of_prompt()` is called by `convert_quiz()` to find the end of the prompt. 

If you test this on an individual quiz, you can look at the `quiz_line_df` to see how the tagging of the line types works. Things are labeled as: "prompt", "extended_prompt", "wrong_answer", "correct_answer", "other", "tag", "empty".

Empty and tag lines are deleted. (But eventually we may want to do something with the tags, so I kept in these labels for now). 
prompt lines are used to find the "extended_prompts" it assumes everything between the beginning of the prompt and the first answer are a part of the prompt. 

The correct and wrong answer declarations are made to be more flexible. But this still only works for multiple choice (no short answers). 

"other" lines are removed at the very end since I'm not sure we need to keep them. 