### PR TITLE
Add Leanpub publish reminder issue

### DIFF
--- a/.github/automatic-issues/publish-leanpub.md
+++ b/.github/automatic-issues/publish-leanpub.md
@@ -1,0 +1,10 @@
+Changes have been merged to `main`.
+
+**Don't forget to publish these changes to [Leanpub](https://leanpub.com/)**
+
+Follow the [`Preview a new version` instructions here](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Publishing-on-Leanpub#hosting-your-course-on-leanpub).
+
+If your course has been published, the process is nearly identical except you will use `Publish a new version`.
+
+This issue will keep a running list of what changes have not yet been published until the issue is closed.
+This reminder is automatically filed by `.github/workflows/file-reminder-issue.yml`. Delete this file if you no longer wish to see these reminders.

--- a/.github/automatic-issues/publish-leanpub.md
+++ b/.github/automatic-issues/publish-leanpub.md
@@ -1,4 +1,4 @@
-Changes have been merged to `main`.
+Changes to the `manuscript` directory have been merged to `main`.
 
 **Don't forget to publish these changes to [Leanpub](https://leanpub.com/)**
 

--- a/.github/workflows/file-reminder-issue.yml
+++ b/.github/workflows/file-reminder-issue.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-
+    paths: [ manuscript/* ]
 jobs:
   reminder:
     runs-on: ubuntu-latest

--- a/.github/workflows/file-reminder-issue.yml
+++ b/.github/workflows/file-reminder-issue.yml
@@ -1,0 +1,26 @@
+name: File reminder issue for Leanpub publishing
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Find issue comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          comment-author: 'github-actions[bot]'
+          body-includes: publish these changes to [Leanpub]
+
+      # If the issue isn't still open, then make a new one
+      - name: Publish Leanpub
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Reminder to publish changes to Leanpub
+          content-filepath: .github/automatic-issues/publish-leanpub.md
+          labels: automated issue


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
I don't know where the issue went, but this will file an issue reminder for publishing to Leanpub if changes are made to the `manuscript` folder. 
